### PR TITLE
Adding support to use date fields as filters in the SOQL queries

### DIFF
--- a/force-app/main/default/classes/QCondition.cls
+++ b/force-app/main/default/classes/QCondition.cls
@@ -36,6 +36,9 @@ public class QCondition {
 		}
 		if (val instanceof String) {
 			return '\'' + String.escapeSingleQuotes((String) val) + '\'';
+		} else if (val instanceof Date) {
+			String dateString = String.valueOf(val);
+			return dateString.substring(0, dateString.indexOf(' '));
 		} else {
 			return val;
 		}


### PR DESCRIPTION
Dynamic SOQL queries are tricky for the use of date fields as filters.

Example:

Q campaignQuery = new Q(Account.SObjectType)
    .add(Q.condition('Start_Date___c').isLessOrEquals(Date.today()));

Salesforce converts that to:

SELECT Id FROM Account WHERE Start_Date___c <= 2018-05-23 00:00:00

Adding those 00:00:00 that makes the query throw the error:

System.QueryException: line 1:77 no viable alternative at character '<EOF>'

If you try to pass directly a String as '2018-05-23', you will get the error:

Query: SELECT Id FROM Account WHERE Start_Date_vod__c <= '2018-05-23'
Error: System.QueryException: value of filter criterion for field 'Start_Date_vod__c' must be of type date and should not be enclosed in quotes.

I couldn't find any way of passing directly a date that is not converted with the 00:00:00 suffix. So I'm submitting this patch to remove those 00:00:00 in the library.
