### PR TITLE
remove Data.com specific account fields so that Q query builder can b…

### DIFF
--- a/force-app/main/default/objects/Account/fields/CleanStatus.field-meta.xml
+++ b/force-app/main/default/objects/Account/fields/CleanStatus.field-meta.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>CleanStatus</fullName>
-    <trackFeedHistory>false</trackFeedHistory>
-</CustomField>

--- a/force-app/main/default/objects/Account/fields/DandbCompanyId.field-meta.xml
+++ b/force-app/main/default/objects/Account/fields/DandbCompanyId.field-meta.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>DandbCompanyId</fullName>
-    <trackFeedHistory>false</trackFeedHistory>
-    <type>Lookup</type>
-</CustomField>

--- a/force-app/main/default/objects/Account/fields/DunsNumber.field-meta.xml
+++ b/force-app/main/default/objects/Account/fields/DunsNumber.field-meta.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>DunsNumber</fullName>
-    <trackFeedHistory>false</trackFeedHistory>
-</CustomField>

--- a/force-app/main/default/objects/Account/fields/NaicsCode.field-meta.xml
+++ b/force-app/main/default/objects/Account/fields/NaicsCode.field-meta.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>NaicsCode</fullName>
-    <trackFeedHistory>false</trackFeedHistory>
-</CustomField>

--- a/force-app/main/default/objects/Account/fields/NaicsDesc.field-meta.xml
+++ b/force-app/main/default/objects/Account/fields/NaicsDesc.field-meta.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>NaicsDesc</fullName>
-    <trackFeedHistory>false</trackFeedHistory>
-</CustomField>

--- a/force-app/main/default/objects/Account/fields/OperatingHoursId.field-meta.xml
+++ b/force-app/main/default/objects/Account/fields/OperatingHoursId.field-meta.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>OperatingHoursId</fullName>
-    <trackFeedHistory>false</trackFeedHistory>
-    <type>Lookup</type>
-</CustomField>

--- a/force-app/main/default/objects/Account/fields/Tradestyle.field-meta.xml
+++ b/force-app/main/default/objects/Account/fields/Tradestyle.field-meta.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>Tradestyle</fullName>
-    <trackFeedHistory>false</trackFeedHistory>
-</CustomField>

--- a/force-app/main/default/objects/Account/fields/YearStarted.field-meta.xml
+++ b/force-app/main/default/objects/Account/fields/YearStarted.field-meta.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>YearStarted</fullName>
-    <trackFeedHistory>false</trackFeedHistory>
-</CustomField>


### PR DESCRIPTION
…e used on org w/o Data.com

Really excited about this class!   Found that I needed to remove a few Data.com specific fields from account in order to install the package from DX to an enterprise sandbox org w/o Data.com.  Developer orgs and scratch orgs w/ developer org shape have these by default enterprise orgs don't.

Thanks
Peter