### PR TITLE
Support parenthetical groupings of logical operators.

### DIFF
--- a/force-app/main/default/classes/Q.cls
+++ b/force-app/main/default/classes/Q.cls
@@ -11,7 +11,7 @@ public class Q {
 
 	private Set<String> fieldList = new Set<String>();
 	private List<QOrder> orders = new List<QOrder>();
-	private List<QCondition> conditions = new List<QCondition>();
+	private List<QICondition> conditions = new List<QICondition>();
 	private List<Q> subQueries = new List<Q>();
 
 	public Q(SObjectType fromType)	{ this.fromText = String.valueOf(fromType); }
@@ -94,6 +94,22 @@ public class Q {
 	}
 
 	/**
+     * Instantiate a parenthetical OR condition group
+     */
+    public static QConditionGroup orGroup() {
+        QOrGroup orGroup = new QOrGroup();
+        return orGroup;
+    }
+
+    /**
+     * Instantiate a parenthetical AND condition group
+     */
+    public static QConditionGroup andGroup() {
+        QAndGroup andGroup = new QAndGroup();
+        return andGroup;
+    }
+
+	/**
 	 * Build the SELECT statement
 	 */
 	public String buildSelect() {
@@ -114,7 +130,7 @@ public class Q {
 	public String buildConditions() {
 		List<String> condList = new List<String>();
 
-		for (QCondition cond : this.conditions) {
+		for (QICondition cond : this.conditions) {
 			condList.add(cond.build());
 		}
 

--- a/force-app/main/default/classes/Q.cls
+++ b/force-app/main/default/classes/Q.cls
@@ -44,7 +44,7 @@ public class Q {
 	/**
 	 * Add a Condition statement
 	 */
-	public Q add(QCondition cnd) {
+	public Q add(QICondition cnd) {
 		this.conditions.add(cnd);
 		return this;
 	}

--- a/force-app/main/default/classes/QAndGroup.cls
+++ b/force-app/main/default/classes/QAndGroup.cls
@@ -5,9 +5,9 @@
 */
 public class QAndGroup extends QConditionGroup {
     public QAndGroup() {
-        super(LogicalOperator.AND_x);
+        super('AND');
     }
     public QAndGroup(List<QICondition> conditions) {
-        super(conditions, LogicalOperator.AND_x);
+        super(conditions, 'AND');
     }
 }

--- a/force-app/main/default/classes/QAndGroup.cls
+++ b/force-app/main/default/classes/QAndGroup.cls
@@ -1,0 +1,13 @@
+/**
+* QAndGroup is used to build a SOQL WHERE clause with parenthetical groupings of logical AND operators
+* @author  Fred Hays
+* @since   2020-02-04
+*/
+public class QAndGroup extends QConditionGroup {
+    public QAndGroup() {
+        super(LogicalOperator.AND_x);
+    }
+    public QAndGroup(List<QICondition> conditions) {
+        super(conditions, LogicalOperator.AND_x);
+    }
+}

--- a/force-app/main/default/classes/QAndGroup.cls-meta.xml
+++ b/force-app/main/default/classes/QAndGroup.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>47.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/QCondition.cls
+++ b/force-app/main/default/classes/QCondition.cls
@@ -3,7 +3,7 @@
 * @author  Jean-Philippe Monette
 * @since   2017-03-21
 */
-public class QCondition {
+public class QCondition implements QICondition {
 
 	public enum ComparisonOperator { EQUALS, NOT_EQUALS, LESS_THAN, LESS_OR_EQUAL, GREATER_THAN, GREATER_OR_EQUAL, IS_LIKE, IS_IN, NOT_IN, INCLUDES, EXCLUDES }
 

--- a/force-app/main/default/classes/QConditionGroup.cls
+++ b/force-app/main/default/classes/QConditionGroup.cls
@@ -1,0 +1,52 @@
+/**
+* QConditionGroup is an abstract class extended by QAandGroup and QOrGroup to build parenthetical groupings 
+* @author  Fred Hays
+* @since   2020-02-04
+*/
+public abstract class QConditionGroup implements QICondition {
+    
+    public enum LogicalOperator { AND_x, OR_x }
+
+    private static Map<String, String> operatorMap = new Map<String, String>
+    {
+        'AND_x' => 'AND',
+        'OR_x' => 'OR'
+    };
+
+    protected List<QICondition> conditions { get; set; }
+
+    protected LogicalOperator operator;
+
+    public Boolean hasConditions {
+        get {
+            return (this.conditions != null && !this.conditions.isEmpty());
+        }
+    }
+
+    public QConditionGroup(LogicalOperator operator) {
+        this(new List<QICondition>(), operator);
+    }
+
+    public QConditionGroup(List<QICondition> conditions, LogicalOperator operator) {
+        this.conditions = conditions;
+        this.operator = operator;
+    }
+
+    public QConditionGroup add(QICondition condition) {
+        this.conditions.add(condition);
+        return this;
+    }
+
+    public String build() {
+
+        String value = '';
+
+        for (QConditionGroup condition : conditions) {
+            if (String.isNotEmpty(value))
+                value += ' ' + operatorMap.get(operator.name()) + ' ';
+            value += condition.build();
+        }
+
+        return '(' + value + ')';
+    }
+}

--- a/force-app/main/default/classes/QConditionGroup.cls
+++ b/force-app/main/default/classes/QConditionGroup.cls
@@ -41,7 +41,7 @@ public abstract class QConditionGroup implements QICondition {
 
         String value = '';
 
-        for (QConditionGroup condition : conditions) {
+        for (QICondition condition : conditions) {
             if (String.isNotEmpty(value))
                 value += ' ' + operatorMap.get(operator.name()) + ' ';
             value += condition.build();

--- a/force-app/main/default/classes/QConditionGroup.cls
+++ b/force-app/main/default/classes/QConditionGroup.cls
@@ -4,18 +4,10 @@
 * @since   2020-02-04
 */
 public abstract class QConditionGroup implements QICondition {
-    
-    public enum LogicalOperator { AND_x, OR_x }
-
-    private static Map<String, String> operatorMap = new Map<String, String>
-    {
-        'AND_x' => 'AND',
-        'OR_x' => 'OR'
-    };
 
     protected List<QICondition> conditions { get; set; }
 
-    protected LogicalOperator operator;
+    protected String operator;
 
     public Boolean hasConditions {
         get {
@@ -23,11 +15,11 @@ public abstract class QConditionGroup implements QICondition {
         }
     }
 
-    public QConditionGroup(LogicalOperator operator) {
+    public QConditionGroup(String operator) {
         this(new List<QICondition>(), operator);
     }
 
-    public QConditionGroup(List<QICondition> conditions, LogicalOperator operator) {
+    public QConditionGroup(List<QICondition> conditions, String operator) {
         this.conditions = conditions;
         this.operator = operator;
     }
@@ -43,7 +35,7 @@ public abstract class QConditionGroup implements QICondition {
 
         for (QICondition condition : conditions) {
             if (String.isNotEmpty(value))
-                value += ' ' + operatorMap.get(operator.name()) + ' ';
+                value += ' ' + operator + ' ';
             value += condition.build();
         }
 

--- a/force-app/main/default/classes/QConditionGroup.cls-meta.xml
+++ b/force-app/main/default/classes/QConditionGroup.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>47.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/QICondition.cls
+++ b/force-app/main/default/classes/QICondition.cls
@@ -1,0 +1,8 @@
+/**
+* QICondition is an interface to be implemented by shared classes that build SOQL conditions
+* @author  Fred Hays
+* @since   2020-02-04
+*/
+public interface QICondition {
+    String build();
+}

--- a/force-app/main/default/classes/QICondition.cls-meta.xml
+++ b/force-app/main/default/classes/QICondition.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>47.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/QOrGroup.cls
+++ b/force-app/main/default/classes/QOrGroup.cls
@@ -5,10 +5,10 @@
 */
 public class QOrGroup extends QConditionGroup {
     public QOrGroup() {
-        super(LogicalOperator.OR_x);
+        super('OR');
     }
 
     public QOrGroup(List<QICondition> conditions) {
-        super(conditions, LogicalOperator.OR_x);
+        super(conditions, 'OR');
     }
 }

--- a/force-app/main/default/classes/QOrGroup.cls
+++ b/force-app/main/default/classes/QOrGroup.cls
@@ -1,0 +1,14 @@
+/**
+* QOrGroup is used to build a SOQL WHERE clause with parenthetical groupings of logical OR operators
+* @author  Fred Hays
+* @since   2020-02-04
+*/
+public class QOrGroup extends QConditionGroup {
+    public QOrGroup() {
+        super(LogicalOperator.OR_x);
+    }
+
+    public QOrGroup(List<QICondition> conditions) {
+        super(conditions, LogicalOperator.OR_x);
+    }
+}

--- a/force-app/main/default/classes/QOrGroup.cls-meta.xml
+++ b/force-app/main/default/classes/QOrGroup.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>47.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/QTest.cls
+++ b/force-app/main/default/classes/QTest.cls
@@ -105,4 +105,56 @@ private class QTest {
 		Database.query(query);
 	}
 
+	@isTest
+    static void testOrGroup() {
+        String query =
+            new Q(Account.SObjectType)
+                .add(Q.orGroup()
+                .add(Q.condition('Name').equalsTo('test'))
+                .add(Q.condition('Name').equalsTo('test'))
+            )
+                .build();
+
+        System.assertEquals('SELECT Id FROM Account WHERE (Name = \'test\' OR Name = \'test\')', query);
+        Database.query(query);
+
+        List<QCondition> conditions = new List<QCondition>();
+        conditions.add(Q.condition('Name').equalsTo('test'));
+        conditions.add(Q.condition('Name').equalsTo('test'));
+        QOrGroup sbOrGroup = new QOrGroup(conditions);
+        query =
+            new Q(Account.SObjectType)
+                .add(sbOrGroup)
+                .build();
+
+        System.assertEquals('SELECT Id FROM Account WHERE (Name = \'test\' OR Name = \'test\')', query);
+        Database.query(query);
+    }
+
+    @isTest
+    static void testAndGroup() {
+        String query =
+            new Q(Account.SObjectType)
+                .add(Q.andGroup()
+                    .add(Q.condition('Name').equalsTo('test'))
+                    .add(Q.condition('Name').equalsTo('test'))
+                )
+                .build();
+
+        System.assertEquals('SELECT Id FROM Account WHERE (Name = \'test\' AND Name = \'test\')', query);
+        Database.query(query);
+
+        List<QCondition> conditions = new List<QCondition>();
+        conditions.add(Q.condition('Name').equalsTo('test'));
+        conditions.add(Q.condition('Name').equalsTo('test'));
+        QAndGroup sbAndGroup = new QAndGroup(conditions);
+        query =
+            new Q(Account.SObjectType)
+                .add(sbAndGroup)
+            .build();
+
+        System.assertEquals('SELECT Id FROM Account WHERE (Name = \'test\' AND Name = \'test\')', query);
+        Database.query(query);
+    }
+
 }

--- a/force-app/main/default/classes/QTest.cls
+++ b/force-app/main/default/classes/QTest.cls
@@ -110,10 +110,10 @@ private class QTest {
         String query =
             new Q(Account.SObjectType)
                 .add(Q.orGroup()
-                .add(Q.condition('Name').equalsTo('test'))
-                .add(Q.condition('Name').equalsTo('test'))
-            )
-                .build();
+                	.add(Q.condition('Name').equalsTo('test'))
+                	.add(Q.condition('Name').equalsTo('test'))
+            	)
+            	.build();
 
         System.assertEquals('SELECT Id FROM Account WHERE (Name = \'test\' OR Name = \'test\')', query);
         Database.query(query);


### PR DESCRIPTION
Support for parenthetical groupings of logical operators.

## Example OR grouping
```java
Q query = new Q(Account.SObjectType)
    .add(Q.orGroup()
        .add(Q.condition('Name').equalsTo('Acme 1'))
        .add(Q.condition('Name').equalsTo('Acme 2'))
    )
    .add(Q.condition('BillingCity').equalsTo('San Diego'));

System.debug(query.build());
//SELECT Id FROM Account WHERE (Name = 'Acme 1' OR Name = 'Acme 2') AND BillingCity = 'San Diego'
```
## Create with list of conditions
```java
List<QCondition> conditions = new List<QCondition>();
conditions.add(Q.condition('Name').isEqualTo('test'));
conditions.add(Q.condition('Name').isEqualTo('test'));
QOrGroup sbOrGroup = new QOrGroup(conditions);
Q query = new Q(Account.SObjectType).add(sbOrGroup);
System.debug(query.build());
//SELECT Id FROM Account WHERE (Name = 'test' AND Name = 'test')
```