### PR TITLE
Support for location-based queries

### DIFF
--- a/force-app/main/default/classes/Q.cls
+++ b/force-app/main/default/classes/Q.cls
@@ -34,6 +34,14 @@ public class Q {
 	}
 
 	/**
+	 * Instantiate a Distance object using location fields
+	 */
+	public static QDistance distanceFrom(String fromFieldName) {
+		QDistance dist = new QDistance(fromFieldName);
+		return dist;
+	}
+
+	/**
 	 * Add an OrderBy statement
 	 */
 	public Q add(QOrder ob) {

--- a/force-app/main/default/classes/QCondition.cls
+++ b/force-app/main/default/classes/QCondition.cls
@@ -3,20 +3,20 @@
 * @author  Jean-Philippe Monette
 * @since   2017-03-21
 */
-public class QCondition implements QICondition {
+public virtual class QCondition implements QICondition {
 
 	public enum ComparisonOperator { EQUALS, NOT_EQUALS, LESS_THAN, LESS_OR_EQUAL, GREATER_THAN, GREATER_OR_EQUAL, IS_LIKE, IS_IN, NOT_IN, INCLUDES, EXCLUDES }
 
-	private ComparisonOperator operatorValue;
+	protected ComparisonOperator operatorValue;
 
-	private String field {
-		private get { return String.escapeSingleQuotes(field); }
-		private set;
+	protected String field {
+		protected get { return String.escapeSingleQuotes(field); }
+		protected set;
 	}
 
-	private Object fieldValue {
-		private get { return formatFieldValue(fieldValue); }
-		private set { fieldValue = value; }
+	protected Object fieldValue {
+		protected get { return formatFieldValue(fieldValue); }
+		protected set { fieldValue = value; }
 	}
 	public QCondition(String field) {
 		this.field = field;
@@ -122,7 +122,7 @@ public class QCondition implements QICondition {
 		return this;
 	}
 
-	public String build() {
+	public virtual String build() {
 		switch on operatorValue {
 			when EQUALS {
 				return field + ' = ' + fieldValue;

--- a/force-app/main/default/classes/QConditionTest.cls
+++ b/force-app/main/default/classes/QConditionTest.cls
@@ -94,4 +94,54 @@ private class QConditionTest {
 		System.assertEquals('Name != null', segment, 'It should output a IS NOT NULL condition.');
 	}
 
+	@isTest
+	static void testDistance() {
+		String segment = new QDistance('BillingAddress').to('LocationField__c').isLessThan(20).build();
+		String expected = 'DISTANCE(BillingAddress, LocationField__c, \'mi\') < 20';
+		System.assertEquals(expected, segment, 'Segment should output a distance condition.');
+	}
+
+	@isTest
+	static void testDistanceGreaterThan() {
+		String segment = new QDistance('BillingAddress').to('LocationField__c').inKilometers().isGreaterThan(20).build();
+		String expected = 'DISTANCE(BillingAddress, LocationField__c, \'km\') > 20';
+		System.assertEquals(expected, segment, 'Segment should output a distance condition.');
+	}
+
+	@isTest
+	static void testDistanceInMiles() {
+		String segment = new QDistance('BillingAddress').to('LocationField__c').inMiles().isGreaterThan(20).build();
+		string expected = 'DISTANCE(BillingAddress, LocationField__c, \'mi\') > 20';
+		System.assertEquals(expected, segment, 'Segment should output a distance condition.');
+	}
+
+	@isTest
+	static void testDistanceInvalidOperator() {
+		String expected = '';
+		try {
+			String segment = new QDistance('BillingAddress').to('LocationField__c').equalsTo(20).build();
+		} catch (QDistance.QDistanceException e) {
+			expected = e.getMessage();
+		}
+		System.assertEquals(expected, 'Invalid operator. DISTANCE supports only the logical operators > and <', 'Should output an exception message.');
+	}
+
+	@isTest
+	static void testDistanceToLocationNotSet() {
+		String expected = '';
+		try {
+			String segment = new QDistance('BillingAddress').isLessThan(20).build();
+		} catch (QDistance.QDistanceException e) {
+			expected = e.getMessage();
+		}
+		System.assertEquals(expected, 'To location is not set. Call to() method to set up.', 'Should output an exception message.');
+	}
+
+	@isTest
+	static void testDistanceLatLon() {
+		String segment = new QDistance('BillingAddress').to(37.775, -122.418).isLessThan(20).build();
+		String expected = 'DISTANCE(BillingAddress, GEOLOCATION(37.775, -122.418), \'mi\') < 20';
+		System.assertEquals(expected, segment, 'Segment should output a distance condition.');
+	}
+
 }

--- a/force-app/main/default/classes/QDistance.cls
+++ b/force-app/main/default/classes/QDistance.cls
@@ -1,0 +1,86 @@
+/**
+* QDistance support distance filters
+* @author  Fred Hays
+* @since   2020-04-22
+*/
+
+public class QDistance extends QCondition {
+	
+	private String distanceUnit {
+		private get;
+		private set;
+	}
+	private String toLocationField { 
+		private get; 
+		private set; 
+	}
+
+	private Decimal toLocationLatitude { 
+		private get; 
+		private set; 
+	}
+
+	private Decimal toLocationLongitude { 
+		private get; 
+		private set; 
+	}
+
+	public QDistance(String fromLocationField) {
+		super(fromLocationField);
+		this.distanceUnit = 'mi';        
+	}
+
+	public QDistance to(String toLocationField) {
+		this.toLocationField = toLocationField;
+		return this;
+	}
+
+	public QDistance to(Decimal toLat, Decimal toLon) {
+		this.toLocationLatitude = toLat;
+		this.toLocationLongitude = toLon;
+		return this;
+	}
+
+	public QDistance inMiles() {
+		this.distanceUnit = 'mi';
+		return this;
+	}
+
+	public QDistance inKilometers() {
+		this.distanceUnit = 'km';
+		return this;
+	}
+
+	public override String build() {
+		if (String.isEmpty(this.toLocationField) && this.toLocationLatitude == null && this.toLocationLongitude == null) {
+			throw new QDistanceException('To location is not set. Call to() method to set up.');
+		}
+
+		String geolocation = '';        
+
+		if (String.isEmpty(this.toLocationField)) {
+			geolocation = String.format('GEOLOCATION({0}, {1})', new String[]{
+				String.valueOf(this.toLocationLatitude), String.valueOf(this.toLocationLongitude)
+			});
+		} else {
+			geolocation = this.toLocationField;
+		}
+
+		String distance = 'DISTANCE(' + super.field + ', ' + geolocation + ', \'' + String.valueOf(this.distanceUnit) + '\')';
+
+		switch on super.operatorValue {
+			when LESS_THAN {
+				return distance + ' < ' + super.fieldValue;
+			}
+			when GREATER_THAN {
+				return distance + ' > ' + super.fieldValue;
+			}
+			when else {
+				throw new QDistanceException('Invalid operator. DISTANCE supports only the logical operators > and <');
+			}
+		}
+	}
+
+	public class QDistanceException extends Exception {}
+
+}

--- a/force-app/main/default/classes/QDistance.cls-meta.xml
+++ b/force-app/main/default/classes/QDistance.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>48.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/QTest.cls
+++ b/force-app/main/default/classes/QTest.cls
@@ -115,59 +115,70 @@ private class QTest {
 	}
 
 	@isTest
-    static void testOrGroup() {
-        String query =
-            new Q(Account.SObjectType)
-                .add(Q.orGroup()
-                	.add(Q.condition('Name').equalsTo('test'))
-                	.add(Q.condition('Name').equalsTo('test'))
-            	)
-            	.build();
+	static void testOrGroup() {
+		String query =
+			new Q(Account.SObjectType)
+				.add(Q.orGroup()
+					.add(Q.condition('Name').equalsTo('test'))
+					.add(Q.condition('Name').equalsTo('test'))
+				)
+				.build();
 
 		String expected = 'SELECT Id FROM Account WHERE (Name = \'test\' OR Name = \'test\')';
-        System.assertEquals(expected, query, 'It should output a query with a condition group.');
-        Database.query(query);
+		System.assertEquals(expected, query, 'It should output a query with a condition group.');
+		Database.query(query);
 
-        List<QCondition> conditions = new List<QCondition>();
-        conditions.add(Q.condition('Name').equalsTo('test'));
-        conditions.add(Q.condition('Name').equalsTo('test'));
-        QOrGroup sbOrGroup = new QOrGroup(conditions);
-        query =
-            new Q(Account.SObjectType)
-                .add(sbOrGroup)
-                .build();
+		List<QCondition> conditions = new List<QCondition>();
+		conditions.add(Q.condition('Name').equalsTo('test'));
+		conditions.add(Q.condition('Name').equalsTo('test'));
+		QOrGroup sbOrGroup = new QOrGroup(conditions);
+		query =
+			new Q(Account.SObjectType)
+				.add(sbOrGroup)
+				.build();
 
 		String expected2 = 'SELECT Id FROM Account WHERE (Name = \'test\' OR Name = \'test\')';
-        System.assertEquals(expected2, query, 'It should output a query with a condition group.');
-        Database.query(query);
-    }
+		System.assertEquals(expected2, query, 'It should output a query with a condition group.');
+		Database.query(query);
+	}
 
-    @isTest
-    static void testAndGroup() {
-        String query =
-            new Q(Account.SObjectType)
-                .add(Q.andGroup()
-                    .add(Q.condition('Name').equalsTo('test'))
-                    .add(Q.condition('Name').equalsTo('test'))
-                )
-                .build();
+	@isTest
+	static void testAndGroup() {
+		String query =
+			new Q(Account.SObjectType)
+				.add(Q.andGroup()
+					.add(Q.condition('Name').equalsTo('test'))
+					.add(Q.condition('Name').equalsTo('test'))
+				)
+				.build();
 
 		String expected = 'SELECT Id FROM Account WHERE (Name = \'test\' AND Name = \'test\')';
-        System.assertEquals(expected, query, 'It should output a query with a condition group.');
-        Database.query(query);
+		System.assertEquals(expected, query, 'It should output a query with a condition group.');
+		Database.query(query);
 
-        List<QCondition> conditions = new List<QCondition>();
-        conditions.add(Q.condition('Name').equalsTo('test'));
-        conditions.add(Q.condition('Name').equalsTo('test'));
-        QAndGroup sbAndGroup = new QAndGroup(conditions);
-        query =
-            new Q(Account.SObjectType)
-                .add(sbAndGroup)
-            .build();
+		List<QCondition> conditions = new List<QCondition>();
+		conditions.add(Q.condition('Name').equalsTo('test'));
+		conditions.add(Q.condition('Name').equalsTo('test'));
+		QAndGroup sbAndGroup = new QAndGroup(conditions);
+		query =
+			new Q(Account.SObjectType)
+				.add(sbAndGroup)
+			.build();
 
 		String expected2 = 'SELECT Id FROM Account WHERE (Name = \'test\' AND Name = \'test\')';
-        System.assertEquals(expected2, query, 'It should output a query with a condition group.');
-        Database.query(query);
-    }
+		System.assertEquals(expected2, query, 'It should output a query with a condition group.');
+		Database.query(query);
+	}
+	
+	@isTest
+	static void testDistance() {
+		String query =
+			new Q(Account.SObjectType)
+				.add(Q.distanceFrom('BillingAddress').to(37.775, -122.418).isLessThan(20))
+				.build();
+		String expected = 'SELECT Id FROM Account WHERE DISTANCE(BillingAddress, GEOLOCATION(37.775, -122.418), \'mi\') < 20';
+		System.assertEquals(expected, query, 'It should output a query with a distance condition.');
+		Database.query(query);
+	}
 
 }


### PR DESCRIPTION
## Location-Based Queries
Reference:
[Location-Based SOQL Queries](https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_soql_geolocate.htm)

Using a custom field as the destiation
```java
Q query = new Q(Account.SObjectType)
    .add(Q.distanceFrom('BillingAddress').to('CustomLocationField__c').isLessThan(20));

System.debug(query.build());
//SELECT Id FROM Account WHERE DISTANCE(BillingAddress, CustomLocationField__c, 'mi') < 20
```

Using Latitude and Longitude as the destination and kilometers as the unit
```java
Q query = new Q(Account.SObjectType)
    .add(Q.distanceFrom('BillingAddress').to(37.775, -122.418).inKilometers().isLessThan(20))

System.debug(query.build());
//SELECT Id FROM Account WHERE DISTANCE(BillingAddress, GEOLOCATION(37.775, -122.418), 'km') < 20
```