### PR TITLE
Sub query support for IN and NOT IN

### DIFF
--- a/force-app/main/default/classes/QCondition.cls
+++ b/force-app/main/default/classes/QCondition.cls
@@ -39,6 +39,8 @@ public class QCondition implements QICondition {
 		} else if (val instanceof Date) {
 			String dateString = String.valueOf(val);
 			return dateString.substring(0, dateString.indexOf(' '));
+		} else if (val instanceof Q) {
+			return ((Q)val).build();
 		} else {
 			return val;
 		}
@@ -92,11 +94,23 @@ public class QCondition implements QICondition {
 		return this;
 	}
 
+	public QCondition isIn(Q subQuery) {
+		this.operatorValue = ComparisonOperator.IS_IN;
+		this.fieldValue = subQuery;
+		return this;
+	}
+
 	public QCondition isNotIn(List<Object> values) {
 		this.operatorValue = ComparisonOperator.NOT_IN;
 		this.fieldValue = values;
 		return this;
 	}
+
+	public QCondition isNotIn(Q subQuery) {
+		this.operatorValue = ComparisonOperator.NOT_IN;
+		this.fieldValue = subQuery;
+		return this;
+	}	
 
 	public QCondition includes(List<Object> values) {
 		this.operatorValue = ComparisonOperator.INCLUDES;

--- a/force-app/main/default/classes/QConditionTest.cls
+++ b/force-app/main/default/classes/QConditionTest.cls
@@ -94,4 +94,18 @@ private class QConditionTest {
 		System.assertEquals('Name != null', segment, 'It should output a IS NOT NULL condition.');
 	}
 
+	@isTest
+	static void testIsInSubQuery() {
+		String segment = new QCondition('Name').isIn(new Q(Account.SObjectType).selectFields(new Set<String> {'Name'})).build();
+		String expected = 'Name IN (SELECT Name FROM Account)';
+		System.assertEquals(expected, segment, 'It should output a IN sub query.');
+	}
+
+	@isTest
+	static void testIsNotInSubQuery() {
+		String segment = new QCondition('Name').isNotIn(new Q(Account.SObjectType).selectFields(new Set<String> {'Name'})).build();
+		String expected = 'Name NOT IN (SELECT Name FROM Account)';
+		System.assertEquals(expected, segment, 'It should output a NOT IN sub query.');
+	}
+
 }

--- a/force-app/main/default/classes/QTest.cls
+++ b/force-app/main/default/classes/QTest.cls
@@ -115,59 +115,79 @@ private class QTest {
 	}
 
 	@isTest
-    static void testOrGroup() {
-        String query =
-            new Q(Account.SObjectType)
-                .add(Q.orGroup()
-                	.add(Q.condition('Name').equalsTo('test'))
-                	.add(Q.condition('Name').equalsTo('test'))
-            	)
-            	.build();
+	static void testOrGroup() {
+		String query =
+			new Q(Account.SObjectType)
+				.add(Q.orGroup()
+					.add(Q.condition('Name').equalsTo('test'))
+					.add(Q.condition('Name').equalsTo('test'))
+				)
+				.build();
 
 		String expected = 'SELECT Id FROM Account WHERE (Name = \'test\' OR Name = \'test\')';
-        System.assertEquals(expected, query, 'It should output a query with a condition group.');
-        Database.query(query);
+		System.assertEquals(expected, query, 'It should output a query with a condition group.');
+		Database.query(query);
 
-        List<QCondition> conditions = new List<QCondition>();
-        conditions.add(Q.condition('Name').equalsTo('test'));
-        conditions.add(Q.condition('Name').equalsTo('test'));
-        QOrGroup sbOrGroup = new QOrGroup(conditions);
-        query =
-            new Q(Account.SObjectType)
-                .add(sbOrGroup)
-                .build();
+		List<QCondition> conditions = new List<QCondition>();
+		conditions.add(Q.condition('Name').equalsTo('test'));
+		conditions.add(Q.condition('Name').equalsTo('test'));
+		QOrGroup sbOrGroup = new QOrGroup(conditions);
+		query =
+			new Q(Account.SObjectType)
+				.add(sbOrGroup)
+				.build();
 
 		String expected2 = 'SELECT Id FROM Account WHERE (Name = \'test\' OR Name = \'test\')';
-        System.assertEquals(expected2, query, 'It should output a query with a condition group.');
-        Database.query(query);
-    }
+		System.assertEquals(expected2, query, 'It should output a query with a condition group.');
+		Database.query(query);
+	}
 
-    @isTest
-    static void testAndGroup() {
-        String query =
-            new Q(Account.SObjectType)
-                .add(Q.andGroup()
-                    .add(Q.condition('Name').equalsTo('test'))
-                    .add(Q.condition('Name').equalsTo('test'))
-                )
-                .build();
+	@isTest
+	static void testAndGroup() {
+		String query =
+			new Q(Account.SObjectType)
+				.add(Q.andGroup()
+					.add(Q.condition('Name').equalsTo('test'))
+					.add(Q.condition('Name').equalsTo('test'))
+				)
+				.build();
 
 		String expected = 'SELECT Id FROM Account WHERE (Name = \'test\' AND Name = \'test\')';
-        System.assertEquals(expected, query, 'It should output a query with a condition group.');
-        Database.query(query);
+		System.assertEquals(expected, query, 'It should output a query with a condition group.');
+		Database.query(query);
 
-        List<QCondition> conditions = new List<QCondition>();
-        conditions.add(Q.condition('Name').equalsTo('test'));
-        conditions.add(Q.condition('Name').equalsTo('test'));
-        QAndGroup sbAndGroup = new QAndGroup(conditions);
-        query =
-            new Q(Account.SObjectType)
-                .add(sbAndGroup)
-            .build();
+		List<QCondition> conditions = new List<QCondition>();
+		conditions.add(Q.condition('Name').equalsTo('test'));
+		conditions.add(Q.condition('Name').equalsTo('test'));
+		QAndGroup sbAndGroup = new QAndGroup(conditions);
+		query =
+			new Q(Account.SObjectType)
+				.add(sbAndGroup)
+			.build();
 
 		String expected2 = 'SELECT Id FROM Account WHERE (Name = \'test\' AND Name = \'test\')';
-        System.assertEquals(expected2, query, 'It should output a query with a condition group.');
-        Database.query(query);
-    }
+		System.assertEquals(expected2, query, 'It should output a query with a condition group.');
+		Database.query(query);
+	}
+	
+	@isTest
+	static void testIsInSubQuery() {
+		String query =		
+			new Q(Account.SObjectType)
+				.add(Q.condition('Name').isIn(new Q(Account.SObjectType).selectFields(new Set<String> {'Name'})))
+				.build();
+		String expected = 'SELECT Id FROM Account WHERE Name IN (SELECT Name FROM Account)';
+		System.assertEquals(expected, query, 'It should output a query with an IN sub query.');
+	}
+
+	@isTest
+	static void testIsNotInSubQuery() {
+		String query =		
+			new Q(Account.SObjectType)
+				.add(Q.condition('Name').isNotIn(new Q(Account.SObjectType).selectFields(new Set<String> {'Name'})))
+				.build();
+		String expected = 'SELECT Id FROM Account WHERE Name NOT IN (SELECT Name FROM Account)';
+		System.assertEquals(expected, query, 'It should output a query with a NOT IN sub query.');
+	}
 
 }


### PR DESCRIPTION
## Inner Joins (IN sub query)

```java
Q query = new Q(Account.SObjectType)
    .addSubquery(new Q('Contacts').selectFields(new Set<String> {'Name'}))
    .add(Q.condition('Id').isIn(new Q(Contact.SObjectType).selectFields(new Set<String> {'AccountId'})));

System.debug(query.build());
//SELECT (SELECT Name FROM Contacts) FROM Account WHERE Id IN (SELECT AccountId FROM Contact)
```